### PR TITLE
Embedded Tweets by WHO cards for updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,14 +200,17 @@
                     <canvas id="myChart2" width="100%" height="60vh"></canvas>
                 </div>
                 <hr>
-                <div class="col-12"style="height: 70%">
+                <div class="col-12" style="height: 500px;">
+                    <a class="twitter-timeline" data-height="500" href="https://twitter.com/WHO?ref_src=twsrc%5Etfw">Tweets by WHO</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+                </div>
+                <div class="col-12"style="height: 55%">
                     <iframe src="https://news.sky.com/topic/coronavirus-8483" height="100%" width="100%" style="overflow: hidden; border: none"></iframe>
                 </div>
             </div>
           
         </div>
     </div>
-
+    
 
     <script src="app.js"></script>
 </body>


### PR DESCRIPTION
Added Tweets by WHO card above the news card that'll show all the tweets by WHO on the page itself. It'll be useful for all the COVID-related updates and guidelines issued by the World Health Organization(WHO). 

Find the screenshot below:

![Screenshot](https://i.ibb.co/VN8KRkG/1.jpg)
