### PR TITLE
Fixed map repeating when zooming out 

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -4,12 +4,14 @@ import "./css/Map.css";
 import { showDataOnMap } from "./util";
 
 function Map({ countries, casesType, center, zoom }) {
+
   return (
     <div className="map">
-      <LeafletMap center={center} zoom={zoom}>
+      <LeafletMap center={center} zoom={zoom} worldCopyJump={false} maxBounds={[[-90,-180],[90,180]]} maxBoundsViscosity={1.0} minZoom={2}>
         <TileLayer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          noWrap={true}
         />
         {showDataOnMap(countries, casesType)}
       </LeafletMap>


### PR DESCRIPTION
Current behavior: zooming out on map results in world map repeating and gray tiles appearing outside of map's bounds

These edits fix this behavior by preventing panning the leaflet map outside of the world's edge, prevents the tiles from loading outside the world's edge, and disables zoom past the world's edge. 